### PR TITLE
Bug fixes on the home page

### DIFF
--- a/css_files/styles.css
+++ b/css_files/styles.css
@@ -295,7 +295,7 @@ h3 {
   text-align: center;
   margin: auto;
   padding: 20px;
-  color: rgb(0, 0, 0);
+  color: #c5c5c5;
 }
 
 .hero-section {
@@ -411,6 +411,7 @@ h3 {
   left: 0;
   padding-top: 230px;
   padding-left: 30px;
+  padding-right: 30px;
 }
 
 .home-container .box .content .trynow-button {

--- a/html_files/toh.html
+++ b/html_files/toh.html
@@ -12,7 +12,7 @@
 
 <body>
   <div class="head">
-    <h1>TOWER OF HENOI</h1>
+    <h1>TOWER OF HANOI</h1>
     <a href="../index.html"><button id="back">Back Home</button></a>
     
   </div>

--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@
           </a>
         </div>
       </div>
+      
       <div class="box">
         <span></span>
         <div class="content">
@@ -229,17 +230,7 @@
           </a>
         </div>
       </div>
-      <div class="box">
-        <span></span>
-        <div class="content">
-          <h1>Sudoku Solver</h1>
-          <h3>9x9</h3>
-          <p>Solves any valid 9x9 sudoku!!</p>
-          <a href="./html_files/sudoku_solver_9x9.html">
-            <div class="trynow-button">TRY NOW!</div>
-          </a>
-        </div>
-      </div>
+
       <div class="box">
         <span></span>
         <div class="content">
@@ -247,6 +238,18 @@
           <h3>8x8</h3>
           <p>Solves any valid 8x8 sudoku!!</p>
           <a href="./html_files/sudoku_solver_8x8.html">
+            <div class="trynow-button">TRY NOW!</div>
+          </a>
+        </div>
+      </div>
+
+      <div class="box">
+        <span></span>
+        <div class="content">
+          <h1>Sudoku Solver</h1>
+          <h3>9x9</h3>
+          <p>Solves any valid 9x9 sudoku!!</p>
+          <a href="./html_files/sudoku_solver_9x9.html">
             <div class="trynow-button">TRY NOW!</div>
           </a>
         </div>
@@ -275,12 +278,13 @@
           </a>
         </div>
       </div>
+      
       <div class="box">
         <span></span>
         <div class="content">
-          <h1>Tower Of henoi</h1>
+          <h1>Tower Of Hanoi</h1>
           <h3>Puzzle</h3>
-          <p>It helps to solve tower of henoi!</p>
+          <p>It helps to solve tower of hanoi!</p>
           <a href="./html_files/toh.html">
             <div class="trynow-button">TRY NOW!</div>
           </a>
@@ -293,12 +297,13 @@
         <div class="content">
           <h1>8 Puzzle Solver</h1>
           <h3>Puzzle</h3>
-          <p> It helps to solve 8 puzzle !</p>
+          <p> It helps to solve 8 puzzle!</p>
           <a href="./html_files/_8_puzzle.html">
             <div class="trynow-button">TRY NOW!</div>
           </a>
         </div>
       </div>
+
       <div class="box">
         <span></span>
         <div class="content">


### PR DESCRIPTION
Made the "Solve it! is a website that contains solvers for common games like Sudoku, Nonogram, Crosswords and more!" more readable.
Improved the descriptions of the solvers in the cards and correct any spelling mistakes Eg: Tower of Henoi-> Tower of Hanoi.
Improved the spacing of the writings in the solvers. Eg: The number solver description needs some padding.
Changed the ordering of 9x9 and 8x8 solver,( 8x8 should come before 9x9)